### PR TITLE
feat(auth-source): add auth-source way of authentication

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,7 @@ jobs:
       matrix:
         emacs_version:
           - "27.1"
-          - "27.2"
-          - "28.2"
-          - "29.4"
+          - "30.2"
           - "snapshot"
 
     steps:
@@ -25,6 +23,14 @@ jobs:
         with:
           version: ${{ matrix.emacs_version }}
 
+      - name: Cache Elpa Packages
+        uses: actions/cache@v6
+        with:
+          path: ~/.emacs.d/elpa
+          key: ${{ runner.os }}-emacs-${{ matrix.emacs_version }}-elpa-${{ hashFiles('Makefile') }}
+          restore-keys: |
+            ${{ runner.os }}-emacs-${{ matrix.emacs_version }}-elpa-
+
       - name: Run tests
         run: make test
 
@@ -32,11 +38,13 @@ jobs:
         run: make compile
 
       - name: Check Formatting
-        if: matrix.emacs_version == 'snapshot'
+        if: matrix.emacs_version == '30.2'
         run: make format-check
 
       - name: Checkdoc
+        if: matrix.emacs_version == '30.2'
         run: make checkdoc
 
       - name: Lint
+        if: matrix.emacs_version == '30.2'
         run: make lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.9] - 2026-07-09
+
+### Added
+
+- **Auth Source**: Native support for Emacs's built-in `auth-source` library, allowing secure and automatic token loading from `~/.authinfo` or `~/.authinfo.gpg`.
+
+### Changed
+
+- **Refactor**: Centralized and streamlined Lichess API requests in `lichess-api.el` using a unified request dispatcher and query serialization.
+- **Refactor**: Consolidated TUI and GUI style rendering logic in `lichess-board.el` around a single `lichess-board--active-style` helper.
+- **Versioning**: Bumped project version to 0.9.
+
 ## [0.8] - 2026-02-03
 
 ### Added

--- a/README.org
+++ b/README.org
@@ -73,12 +73,24 @@ Clone and add to your load path:
 (require 'lichess)
 #+end_src
 * Configuration
-** Authenticaton
+** Authentication
 Some commands require a personal API token (e.g., playing games, viewing protected user data).
 
 1. Go to [[https://lichess.org/account/oauth/token]]
 2. Create a token with appropriate scopes.
-3. Configure it in Emacs:
+3. Configure it in Emacs using either of the following methods:
+
+*** Method A: Standard =auth-source= (Recommended)
+Store your token securely using Emacs's built-in =auth-source= library (available out-of-the-box). Add the following line to your =~/.authinfo= or =~/.authinfo.gpg=:
+
+#+begin_src text
+machine lichess.org password YOUR_TOKEN_HERE
+#+end_src
+
+No additional configuration is required in Emacs; the package will automatically resolve the token.
+
+*** Method B: Variable Configuration
+Alternatively, set the variable directly in your configuration file:
 
 #+begin_src elisp
 (setq lichess-token "YOUR_TOKEN_HERE")
@@ -120,7 +132,8 @@ Here is a complete configuration using =use-package=:
 (use-package lichess
   :commands (lichess lichess-tv lichess-game-watch)
   :custom
-  (lichess-token "YOUR_TOKEN")
+  ;; Optional: set token directly (or use ~/.authinfo)
+  ;; (lichess-token "YOUR_TOKEN")
   (lichess-core-chess-font "DejaVu Sans Mono")
   (lichess-board-gui-light-square-color "#f0d9b5")
   (lichess-board-gui-dark-square-color "#b58863")

--- a/lichess-ai.el
+++ b/lichess-ai.el
@@ -2,7 +2,7 @@
 ;;
 ;; Copyright (C) 2025-2026  Alexandr Timchenko
 ;; URL: https://github.com/tmythicator/Lichess.el
-;; Version: 0.8
+;; Version: 0.9
 ;; Package-Requires: ((emacs "27.1"))
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;

--- a/lichess-announce.el
+++ b/lichess-announce.el
@@ -2,7 +2,7 @@
 ;;
 ;; Copyright (C) 2025-2026  Alexandr Timchenko
 ;; URL: https://github.com/tmythicator/Lichess.el
-;; Version: 0.8
+;; Version: 0.9
 ;; Package-Requires: ((emacs "27.1"))
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;

--- a/lichess-api.el
+++ b/lichess-api.el
@@ -2,7 +2,7 @@
 ;;
 ;; Copyright (C) 2025-2026  Alexandr Timchenko
 ;; URL: https://github.com/tmythicator/Lichess.el
-;; Version: 0.8
+;; Version: 0.9
 ;; Package-Requires: ((emacs "27.1"))
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;

--- a/lichess-api.el
+++ b/lichess-api.el
@@ -19,19 +19,22 @@
   "Function used to perform HTTP requests.
 It must accept: (ENDPOINT CALLBACK &rest PLIST).")
 
-(defun lichess-api--call-json (endpoint callback &optional headers anonymous)
+(defun lichess-api--call-json
+    (endpoint callback &optional headers anonymous)
   "GET JSON from ENDPOINT and call CALLBACK.
 Optional HEADERS is an alist of headers.
 If ANONYMOUS is non-nil, the request does not include authorization."
   (funcall lichess-api-request-function
-           endpoint callback
+           endpoint
+           callback
            :method "GET"
            :accept "application/json"
            :headers headers
            :parse 'json
            :anonymous anonymous))
 
-(defun lichess-api--call-post (endpoint params callback &optional parse-type)
+(defun lichess-api--call-post
+    (endpoint params callback &optional parse-type)
   "POST to ENDPOINT with PARAMS and call CALLBACK.
 PARAMS is an alist of key-value parameters.
 PARSE-TYPE controls response parsing: `json' (default) or `raw'."
@@ -39,7 +42,11 @@ PARSE-TYPE controls response parsing: `json' (default) or `raw'."
            endpoint callback
            :method "POST"
            :data (and params (url-build-query-string params))
-           :headers (and params '(("Content-Type" . "application/x-www-form-urlencoded")))
+           :headers
+           (and params
+                '(("Content-Type"
+                   .
+                   "application/x-www-form-urlencoded")))
            :parse (or parse-type 'json)))
 
 ;;; TV
@@ -52,8 +59,7 @@ PARSE-TYPE controls response parsing: `json' (default) or `raw'."
   "Fetch top broadcasts.  CALLBACK is called with (STATUS . DATA).
 NB is count (default 20)."
   (lichess-api--call-json
-   (format "/api/broadcast/top?nb=%d" (or nb 20))
-   callback))
+   (format "/api/broadcast/top?nb=%d" (or nb 20)) callback))
 
 (defun lichess-api-get-broadcast-round (url callback)
   "Fetch broadcast round data for URL.
@@ -86,10 +92,10 @@ TEXT-MODE: If non-nil, parse response as `raw' text."
            ("clock.increment" ,(number-to-string increment)))))
     (when fen
       (push `("fen" ,fen) params))
-    (lichess-api--call-post "/api/challenge/ai"
-                            params
-                            callback
-                            (if text-mode 'raw 'json))))
+    (lichess-api--call-post "/api/challenge/ai" params callback
+                            (if text-mode
+                                'raw
+                              'json))))
 
 (defun lichess-api-challenge-user
     (username rated color limit increment variant callback)
@@ -101,14 +107,15 @@ INCREMENT: Clock increment in seconds.
 VARIANT: e.g., \"standard\".
 CALLBACK: (STATUS . DATA)."
   (let ((params
-         `(("rated" ,(if rated "true" "false"))
+         `(("rated" ,(if rated
+                 "true"
+               "false"))
            ("color" ,(symbol-name color))
            ("clock.limit" ,(number-to-string limit))
            ("clock.increment" ,(number-to-string increment))
            ("variant" ,variant))))
-    (lichess-api--call-post (format "/api/challenge/%s" username)
-                            params
-                            callback)))
+    (lichess-api--call-post
+     (format "/api/challenge/%s" username) params callback)))
 
 (defun lichess-api-get-challenges (callback)
   "Fetch current challenges (incoming and outgoing).
@@ -118,12 +125,14 @@ CALLBACK: (STATUS . DATA)."
 (defun lichess-api-cancel-challenge (id callback)
   "Cancel challenge with ID.
 CALLBACK: (STATUS . DATA)."
-  (lichess-api--call-post (format "/api/challenge/%s/cancel" id) nil callback))
+  (lichess-api--call-post
+   (format "/api/challenge/%s/cancel" id) nil callback))
 
 (defun lichess-api-accept-challenge (id callback)
   "Accept challenge with ID.
 CALLBACK: (STATUS . DATA)."
-  (lichess-api--call-post (format "/api/challenge/%s/accept" id) nil callback))
+  (lichess-api--call-post
+   (format "/api/challenge/%s/accept" id) nil callback))
 
 (defun lichess-api-get-following (callback)
   "Fetch the list of users followed by current user.
@@ -139,8 +148,10 @@ CALLBACK: (STATUS . DATA)."
   "Fetch cloud evaluation for FEN.
 CALLBACK receives evaluation string or :unavailable."
   (let ((encoded-fen (url-hexify-string fen)))
-    (lichess-api--call-json
-     (format "/api/cloud-eval?fen=%s" encoded-fen) callback nil t)))
+    (lichess-api--call-json (format "/api/cloud-eval?fen=%s"
+                                    encoded-fen)
+                            callback
+                            nil t)))
 
 ;;; Board API (Moves/Game)
 (defun lichess-api-board-move (game-id move callback)
@@ -158,7 +169,9 @@ CALLBACK receives evaluation string or :unavailable."
 ANSWER is `yes' or `no' (to decline).
 CALLBACK: (STATUS . DATA)."
   (lichess-api--call-post
-   (format "/api/board/game/%s/draw/%s" game-id (symbol-name answer))
+   (format "/api/board/game/%s/draw/%s"
+           game-id
+           (symbol-name answer))
    nil callback))
 
 (defun lichess-api-stream-game-url (game-id)

--- a/lichess-api.el
+++ b/lichess-api.el
@@ -15,18 +15,45 @@
 
 (require 'lichess-http)
 
+(defvar lichess-api-request-function #'lichess-http-request
+  "Function used to perform HTTP requests.
+It must accept: (ENDPOINT CALLBACK &rest PLIST).")
+
+(defun lichess-api--call-json (endpoint callback &optional headers anonymous)
+  "GET JSON from ENDPOINT and call CALLBACK.
+Optional HEADERS is an alist of headers.
+If ANONYMOUS is non-nil, the request does not include authorization."
+  (funcall lichess-api-request-function
+           endpoint callback
+           :method "GET"
+           :accept "application/json"
+           :headers headers
+           :parse 'json
+           :anonymous anonymous))
+
+(defun lichess-api--call-post (endpoint params callback &optional parse-type)
+  "POST to ENDPOINT with PARAMS and call CALLBACK.
+PARAMS is an alist of key-value parameters.
+PARSE-TYPE controls response parsing: `json' (default) or `raw'."
+  (funcall lichess-api-request-function
+           endpoint callback
+           :method "POST"
+           :data (and params (url-build-query-string params))
+           :headers (and params '(("Content-Type" . "application/x-www-form-urlencoded")))
+           :parse (or parse-type 'json)))
+
 ;;; TV
 (defun lichess-api-get-tv-channels (callback)
   "Fetch TV channels.  CALLBACK received (STATUS . DATA)."
-  (lichess-http-json "/api/tv/channels" callback))
+  (lichess-api--call-json "/api/tv/channels" callback))
 
 ;;; Broadcasts
 (defun lichess-api-get-broadcasts (callback &optional nb)
   "Fetch top broadcasts.  CALLBACK is called with (STATUS . DATA).
 NB is count (default 20)."
-  (let ((n (or nb 20)))
-    (lichess-http-json
-     (format "/api/broadcast/top?nb=%d" n) callback)))
+  (lichess-api--call-json
+   (format "/api/broadcast/top?nb=%d" (or nb 20))
+   callback))
 
 (defun lichess-api-get-broadcast-round (url callback)
   "Fetch broadcast round data for URL.
@@ -35,12 +62,11 @@ Convert URL to API path:
 `/api/{fullbroadcastlink}`.
 CALLBACK is called with (STATUS . DATA)."
   (let ((path (replace-regexp-in-string "^.*lichess.org" "/api" url)))
-    (lichess-http-json
-     path (lambda (res) (funcall callback res)) nil t)))
+    (lichess-api--call-json path callback nil t)))
 
 (defun lichess-api-get-game (game-id callback)
   "Fetch game data for GAME-ID.  CALLBACK: (STATUS . DATA)."
-  (lichess-http-json (format "/api/game/%s" game-id) callback))
+  (lichess-api--call-json (format "/api/game/%s" game-id) callback))
 
 ;;; Challenges / AI
 (defun lichess-api-challenge-ai
@@ -53,24 +79,17 @@ INCREMENT: Clock increment in seconds.
 FEN: Optional starting position.
 CALLBACK: (STATUS . DATA).
 TEXT-MODE: If non-nil, parse response as `raw' text."
-  (let* ((params
-          `(("level" ,(number-to-string level))
-            ("color" ,(symbol-name color))
-            ("clock.limit" ,(number-to-string limit))
-            ("clock.increment" ,(number-to-string increment))))
-         (final-params
-          (if fen
-              (cons `("fen" ,fen) params)
-            params)))
-    (lichess-http-request
-     "/api/challenge/ai" callback
-     :method "POST"
-     :data (url-build-query-string final-params)
-     :headers '(("Content-Type" . "application/x-www-form-urlencoded"))
-     :parse
-     (if text-mode
-         'raw
-       'json))))
+  (let ((params
+         `(("level" ,(number-to-string level))
+           ("color" ,(symbol-name color))
+           ("clock.limit" ,(number-to-string limit))
+           ("clock.increment" ,(number-to-string increment)))))
+    (when fen
+      (push `("fen" ,fen) params))
+    (lichess-api--call-post "/api/challenge/ai"
+                            params
+                            callback
+                            (if text-mode 'raw 'json))))
 
 (defun lichess-api-challenge-user
     (username rated color limit increment variant callback)
@@ -81,88 +100,66 @@ LIMIT: Clock limit in seconds.
 INCREMENT: Clock increment in seconds.
 VARIANT: e.g., \"standard\".
 CALLBACK: (STATUS . DATA)."
-  (let* ((params
-          `(("rated" ,(if rated
-                  "true"
-                "false"))
-            ("color" ,(symbol-name color))
-            ("clock.limit" ,(number-to-string limit))
-            ("clock.increment" ,(number-to-string increment))
-            ("variant" ,variant))))
-    (lichess-http-request
-     (format "/api/challenge/%s" username)
-     callback
-     :method "POST"
-     :data (url-build-query-string params)
-     :headers
-     '(("Content-Type" . "application/x-www-form-urlencoded"))
-     :parse 'json)))
+  (let ((params
+         `(("rated" ,(if rated "true" "false"))
+           ("color" ,(symbol-name color))
+           ("clock.limit" ,(number-to-string limit))
+           ("clock.increment" ,(number-to-string increment))
+           ("variant" ,variant))))
+    (lichess-api--call-post (format "/api/challenge/%s" username)
+                            params
+                            callback)))
 
 (defun lichess-api-get-challenges (callback)
   "Fetch current challenges (incoming and outgoing).
 CALLBACK: (STATUS . DATA)."
-  (lichess-http-json "/api/challenge" callback))
+  (lichess-api--call-json "/api/challenge" callback))
 
 (defun lichess-api-cancel-challenge (id callback)
   "Cancel challenge with ID.
 CALLBACK: (STATUS . DATA)."
-  (lichess-http-request
-   (format "/api/challenge/%s/cancel" id)
-   callback
-   :method "POST"
-   :parse 'json))
+  (lichess-api--call-post (format "/api/challenge/%s/cancel" id) nil callback))
 
 (defun lichess-api-accept-challenge (id callback)
   "Accept challenge with ID.
 CALLBACK: (STATUS . DATA)."
-  (lichess-http-request
-   (format "/api/challenge/%s/accept" id)
-   callback
-   :method "POST"
-   :parse 'json))
+  (lichess-api--call-post (format "/api/challenge/%s/accept" id) nil callback))
 
 (defun lichess-api-get-following (callback)
   "Fetch the list of users followed by current user.
 CALLBACK: (STATUS . DATA)."
-  (lichess-http-request
-   "/api/rel/following"
-   callback
-   :accept "application/x-ndjson"
-   :parse 'raw))
+  (funcall lichess-api-request-function
+           "/api/rel/following"
+           callback
+           :accept "application/x-ndjson"
+           :parse 'raw))
 
 ;;; Cloud Eval
 (defun lichess-api-cloud-eval (fen callback)
   "Fetch cloud evaluation for FEN.
 CALLBACK receives evaluation string or :unavailable."
   (let ((encoded-fen (url-hexify-string fen)))
-    (lichess-http-json
-     (format "/api/cloud-eval?fen=%s" encoded-fen) callback nil
-     t))) ;; anonymous = true (cloud eval is public/anon)
+    (lichess-api--call-json
+     (format "/api/cloud-eval?fen=%s" encoded-fen) callback nil t)))
 
 ;;; Board API (Moves/Game)
 (defun lichess-api-board-move (game-id move callback)
   "Make a MOVE (UCI) in GAME-ID."
-  (lichess-http-request
-   (format "/api/board/game/%s/move/%s" game-id move) callback
-   :method "POST"))
+  (lichess-api--call-post
+   (format "/api/board/game/%s/move/%s" game-id move) nil callback))
 
 (defun lichess-api-board-resign (game-id callback)
   "Resign GAME-ID.  CALLBACK: (STATUS . DATA)."
-  (lichess-http-request
-   (format "/api/board/game/%s/resign" game-id)
-   callback
-   :method "POST"))
+  (lichess-api--call-post
+   (format "/api/board/game/%s/resign" game-id) nil callback))
 
 (defun lichess-api-board-draw (game-id answer callback)
   "Offer or accept draw in GAME-ID.
 ANSWER is `yes' or `no' (to decline).
 CALLBACK: (STATUS . DATA)."
-  (lichess-http-request
-   (format "/api/board/game/%s/draw/%s"
-           game-id
-           (symbol-name answer))
-   callback
-   :method "POST"))
+  (lichess-api--call-post
+   (format "/api/board/game/%s/draw/%s" game-id (symbol-name answer))
+   nil callback))
 
 (defun lichess-api-stream-game-url (game-id)
   "Return NDJSON stream URL for spectator GAME-ID."

--- a/lichess-board-gui.el
+++ b/lichess-board-gui.el
@@ -2,7 +2,7 @@
 ;;
 ;; Copyright (C) 2025-2026  Alexandr Timchenko
 ;; URL: https://github.com/tmythicator/Lichess.el
-;; Version: 0.8
+;; Version: 0.9
 ;; Package-Requires: ((emacs "27.1"))
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/lichess-board-tui.el
+++ b/lichess-board-tui.el
@@ -2,7 +2,7 @@
 ;;
 ;; Copyright (C) 2025-2026  Alexandr Timchenko
 ;; URL: https://github.com/tmythicator/Lichess.el
-;; Version: 0.8
+;; Version: 0.9
 ;; Package-Requires: ((emacs "27.1"))
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/lichess-board.el
+++ b/lichess-board.el
@@ -2,7 +2,7 @@
 ;;
 ;; Copyright (C) 2025-2026  Alexandr Timchenko
 ;; URL: https://github.com/tmythicator/Lichess.el
-;; Version: 0.8
+;; Version: 0.9
 ;; Package-Requires: ((emacs "27.1"))
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/lichess-board.el
+++ b/lichess-board.el
@@ -48,7 +48,10 @@ EVAL and INFO are read from POS."
 (defun lichess-board-draw-heading (pos &optional perspective)
   "Render heading string for POS using global style and PERSPECTIVE."
   (let* ((style (lichess-board--active-style))
-         (display-style (if (string= style "svg") "SVG" style)))
+         (display-style
+          (if (string= style "svg")
+              "SVG"
+            style)))
     (lichess-board-tui-draw-heading pos display-style perspective)))
 
 (defun lichess-board-insert-board

--- a/lichess-board.el
+++ b/lichess-board.el
@@ -28,38 +28,39 @@ Values: \"unicode\", \"ascii\"."
   :type '(choice (const "unicode") (const "ascii"))
   :group 'lichess)
 
+(defun lichess-board--gui-p ()
+  "Return non-nil if GUI SVG rendering is active."
+  (and (lichess-board-gui-available-p)
+       (string= lichess-board-gui-preferred-style "svg")))
+
+(defun lichess-board--active-style ()
+  "Return active style string based on environment capability and preferences."
+  (if (lichess-board-gui-available-p)
+      (or lichess-board-gui-preferred-style "svg")
+    (or lichess-board-tui-preferred-style "unicode")))
+
+(defun lichess-board--tui-style ()
+  "Return the TUI style name, resolving \"svg\" to fallback \"unicode\"."
+  (let ((style (lichess-board--active-style)))
+    (if (string= style "svg")
+        "unicode"
+      style)))
+
 (defun lichess-board-draw (pos &optional perspective highlights)
   "Render POS as a string.
 PERSPECTIVE: \`white', \`black', \`auto'.
 HIGHLIGHTS: List of squares to highlight.
 EVAL and INFO are read from POS."
-  (let* ((gui-avail (lichess-board-gui-available-p))
-         (style
-          (if gui-avail
-              lichess-board-gui-preferred-style
-            lichess-board-tui-preferred-style)))
-    (if (and (string= style "svg") gui-avail)
-        (lichess-board-gui-draw
-         pos perspective highlights (plist-get pos :eval))
-      (let ((tui-style
-             (if (string= style "svg")
-                 "unicode"
-               style)))
-        (lichess-board-tui-draw pos tui-style perspective)))))
+  (if (lichess-board--gui-p)
+      (lichess-board-gui-draw
+       pos perspective highlights (plist-get pos :eval))
+    (lichess-board-tui-draw pos (lichess-board--tui-style) perspective)))
 
 (defun lichess-board-draw-heading (pos &optional perspective)
   "Render heading string for POS using global style and PERSPECTIVE."
-  (let* ((gui-avail (lichess-board-gui-available-p))
-         (style
-          (if gui-avail
-              lichess-board-gui-preferred-style
-            lichess-board-tui-preferred-style))
-         (display-style
-          (if (and gui-avail (string= style "svg"))
-              "SVG"
-            (if (string= style "svg")
-                "unicode"
-              style))))
+  (let ((display-style (if (lichess-board--gui-p)
+                           "SVG"
+                         (lichess-board--tui-style))))
     (lichess-board-tui-draw-heading pos display-style perspective)))
 
 (defun lichess-board-insert-board
@@ -68,23 +69,9 @@ EVAL and INFO are read from POS."
 PERSPECTIVE: `white`, `black`, or `auto`.
 HIGHLIGHTS: List of squares to highlight.
 Handles face application for TUI modes, avoiding interference with GUI SVGs."
-  (let* ((gui-avail (lichess-board-gui-available-p))
-         (style
-          (if gui-avail
-              lichess-board-gui-preferred-style
-            lichess-board-tui-preferred-style))
-         (gui-p (and gui-avail (string= style "svg")))
-         (board-str
-          (if gui-p
-              (lichess-board-gui-draw
-               pos perspective highlights (plist-get pos :eval))
-            (let ((tui-style
-                   (if (string= style "svg")
-                       "unicode"
-                     style)))
-              (lichess-board-tui-draw pos tui-style perspective))))
-         (start (point)))
-    (insert board-str)
+  (let ((gui-p (lichess-board--gui-p))
+        (start (point)))
+    (insert (lichess-board-draw pos perspective highlights))
     (unless gui-p
       (add-text-properties
        start (point) '(face lichess-core-board-face)))))

--- a/lichess-board.el
+++ b/lichess-board.el
@@ -28,39 +28,27 @@ Values: \"unicode\", \"ascii\"."
   :type '(choice (const "unicode") (const "ascii"))
   :group 'lichess)
 
-(defun lichess-board--gui-p ()
-  "Return non-nil if GUI SVG rendering is active."
-  (and (lichess-board-gui-available-p)
-       (string= lichess-board-gui-preferred-style "svg")))
-
 (defun lichess-board--active-style ()
   "Return active style string based on environment capability and preferences."
   (if (lichess-board-gui-available-p)
       (or lichess-board-gui-preferred-style "svg")
     (or lichess-board-tui-preferred-style "unicode")))
 
-(defun lichess-board--tui-style ()
-  "Return the TUI style name, resolving \"svg\" to fallback \"unicode\"."
-  (let ((style (lichess-board--active-style)))
-    (if (string= style "svg")
-        "unicode"
-      style)))
-
 (defun lichess-board-draw (pos &optional perspective highlights)
   "Render POS as a string.
 PERSPECTIVE: \`white', \`black', \`auto'.
 HIGHLIGHTS: List of squares to highlight.
 EVAL and INFO are read from POS."
-  (if (lichess-board--gui-p)
-      (lichess-board-gui-draw
-       pos perspective highlights (plist-get pos :eval))
-    (lichess-board-tui-draw pos (lichess-board--tui-style) perspective)))
+  (let ((style (lichess-board--active-style)))
+    (if (string= style "svg")
+        (lichess-board-gui-draw
+         pos perspective highlights (plist-get pos :eval))
+      (lichess-board-tui-draw pos style perspective))))
 
 (defun lichess-board-draw-heading (pos &optional perspective)
   "Render heading string for POS using global style and PERSPECTIVE."
-  (let ((display-style (if (lichess-board--gui-p)
-                           "SVG"
-                         (lichess-board--tui-style))))
+  (let* ((style (lichess-board--active-style))
+         (display-style (if (string= style "svg") "SVG" style)))
     (lichess-board-tui-draw-heading pos display-style perspective)))
 
 (defun lichess-board-insert-board
@@ -69,10 +57,10 @@ EVAL and INFO are read from POS."
 PERSPECTIVE: `white`, `black`, or `auto`.
 HIGHLIGHTS: List of squares to highlight.
 Handles face application for TUI modes, avoiding interference with GUI SVGs."
-  (let ((gui-p (lichess-board--gui-p))
+  (let ((style (lichess-board--active-style))
         (start (point)))
     (insert (lichess-board-draw pos perspective highlights))
-    (unless gui-p
+    (unless (string= style "svg")
       (add-text-properties
        start (point) '(face lichess-core-board-face)))))
 

--- a/lichess-broadcast-list.el
+++ b/lichess-broadcast-list.el
@@ -2,7 +2,7 @@
 ;;
 ;; Copyright (C) 2025-2026  Alexandr Timchenko
 ;; URL: https://github.com/tmythicator/Lichess.el
-;; Version: 0.8
+;; Version: 0.9
 ;; Package-Requires: ((emacs "27.1"))
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;

--- a/lichess-broadcast-list.el
+++ b/lichess-broadcast-list.el
@@ -116,7 +116,7 @@
   (if-let* ((button (or btn (button-at (point))))
             (url (button-get button 'lichess-url))
             (round-id (button-get button 'lichess-round-id)))
-    (lichess-broadcast-view-watch-round round-id url)
+      (lichess-broadcast-view-watch-round round-id url)
     (message "No broadcast found at point.")))
 
 (provide 'lichess-broadcast-list)

--- a/lichess-broadcast-view.el
+++ b/lichess-broadcast-view.el
@@ -2,7 +2,7 @@
 ;;
 ;; Copyright (C) 2025-2026  Alexandr Timchenko
 ;; URL: https://github.com/tmythicator/Lichess.el
-;; Version: 0.8
+;; Version: 0.9
 ;; Package-Requires: ((emacs "27.1"))
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;

--- a/lichess-challenge-list.el
+++ b/lichess-challenge-list.el
@@ -2,7 +2,7 @@
 
 ;; Copyright (C) 2025-2026  Alexandr Timchenko
 ;; URL: https://github.com/tmythicator/Lichess.el
-;; Version: 0.8
+;; Version: 0.9
 ;; Package-Requires: ((emacs "27.1"))
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/lichess-challenge.el
+++ b/lichess-challenge.el
@@ -2,7 +2,7 @@
 ;;
 ;; Copyright (C) 2025-2026  Alexandr Timchenko
 ;; URL: https://github.com/tmythicator/Lichess.el
-;; Version: 0.8
+;; Version: 0.9
 ;; Package-Requires: ((emacs "27.1"))
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;

--- a/lichess-core.el
+++ b/lichess-core.el
@@ -2,7 +2,7 @@
 ;;
 ;; Copyright (C) 2025-2026  Alexandr Timchenko
 ;; URL: https://github.com/tmythicator/Lichess.el
-;; Version: 0.8
+;; Version: 0.9
 ;; Package-Requires: ((emacs "27.1"))
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;; See LICENSE for details.

--- a/lichess-core.el
+++ b/lichess-core.el
@@ -18,7 +18,6 @@
 (require 'url)
 (require 'cl-lib)
 (require 'lichess-http)
-(require 'lichess-http)
 (require 'lichess-util)
 
 (defconst lichess-core-variants

--- a/lichess-debug.el
+++ b/lichess-debug.el
@@ -2,7 +2,7 @@
 ;;
 ;; Copyright (C) 2025-2026  Alexandr Timchenko
 ;; URL: https://github.com/tmythicator/Lichess.el
-;; Version: 0.8
+;; Version: 0.9
 ;; Package-Requires: ((emacs "27.1"))
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;; See LICENSE for details.

--- a/lichess-debug.el
+++ b/lichess-debug.el
@@ -43,58 +43,57 @@ ARGS are passed to `format`."
   "Check auth and show /account + /account/playing."
   (interactive)
   (lichess-debug--log "Lichess diagnostics\n")
-  (if (not
-       (and (boundp 'lichess-token)
-            (stringp lichess-token)
-            (> (length lichess-token) 10)))
-      (lichess-debug--log
-       "Set lichess-token for authenticated calls.")
-    (lichess-debug--log "/api/account …")
-    (lichess-http-json
-     "/api/account"
-     (lambda (res)
-       (if (/= (car res) 200)
-           (lichess-debug--log "HTTP %s /account" (car res))
-         (let ((j (cdr res)))
-           (lichess-debug--log "Auth OK as %s"
-                               (alist-get 'username j))))
-       (lichess-debug--log "/api/account/playing …")
-       (lichess-http-json
-        "/api/account/playing"
-        (lambda (res2)
-          (pcase (car res2)
-            (200 (let* ((j (cdr res2))
-                        (games (alist-get 'nowPlaying j))
-                        (n (length games)))
-                   (lichess-debug--log (if (> n 0)
-                                           "%d ongoing game(s)"
-                                         "nowPlaying = []")
-                                       n)))
-            (_
-             (lichess-debug--log "HTTP %s /account/playing"
-                                 (car res2))))))))))
+  (let ((token (lichess-token)))
+    (if (not (and token (stringp token) (> (length token) 10)))
+        (lichess-debug--log
+         "Set lichess-token for authenticated calls.")
+      (lichess-debug--log "/api/account …")
+      (lichess-http-json
+       "/api/account"
+       (lambda (res)
+         (if (/= (car res) 200)
+             (lichess-debug--log "HTTP %s /account" (car res))
+           (let ((j (cdr res)))
+             (lichess-debug--log "Auth OK as %s"
+                                 (alist-get 'username j))))
+         (lichess-debug--log "/api/account/playing …")
+         (lichess-http-json
+          "/api/account/playing"
+          (lambda (res2)
+            (pcase (car res2)
+              (200 (let* ((j (cdr res2))
+                          (games (alist-get 'nowPlaying j))
+                          (n (length games)))
+                     (lichess-debug--log (if (> n 0)
+                                             "%d ongoing game(s)"
+                                           "nowPlaying = []")
+                                         n)))
+              (_
+               (lichess-debug--log "HTTP %s /account/playing"
+                                   (car res2)))))))))))
 
 ;;;###autoload
 (defun lichess-debug-following ()
   "Check /api/rel/following and show raw output."
   (interactive)
   (lichess-debug--log "Lichess following diagnostics\n")
-  (if (not (and (boundp 'lichess-token) (stringp lichess-token)))
-      (lichess-debug--log "Set lichess-token first.")
-    (lichess-debug--log "Fetching /api/rel/following …")
-    (lichess-api-get-following
-     (lambda (res)
-       (let ((status (car res))
-             (data (cdr res)))
-         (lichess-debug--log "HTTP %d response received" status)
-         (if (= status 200)
+  (let ((token (lichess-token)))
+    (if (not (and token (stringp token)))
+        (lichess-debug--log "Set lichess-token first.")
+      (lichess-debug--log "Fetching /api/rel/following …")
+      (lichess-api-get-following
+       (lambda (res)
+         (let ((status (car res))
+               (data (cdr res)))
+           (lichess-debug--log "HTTP %d response received" status)
+           (if (= status 200)
              (progn
                (lichess-debug--log "Data length: %d chars"
                                    (length data))
                (lichess-debug--log "--- RAW DATA START ---")
                (lichess-debug--log "%s" data)
                (lichess-debug--log "--- RAW DATA END ---"))
-           (lichess-debug--log "Error response: %s" data)))))))
+           (lichess-debug--log "Error response: %s" data))))))))
 
 ;;;###autoload
 (defun lichess-debug-game-stream (id)

--- a/lichess-debug.el
+++ b/lichess-debug.el
@@ -20,6 +20,7 @@
 (require 'lichess-util)
 
 (declare-function ielm-change-working-buffer "ielm" (buf))
+(declare-function lichess-token "lichess")
 
 (defvar lichess-debug-diagnose-buf "*Lichess Diagnose*")
 (defvar lichess-debug-tv-buf "*(Debug) Lichess TV*")
@@ -61,13 +62,14 @@ ARGS are passed to `format`."
           "/api/account/playing"
           (lambda (res2)
             (pcase (car res2)
-              (200 (let* ((j (cdr res2))
-                          (games (alist-get 'nowPlaying j))
-                          (n (length games)))
-                     (lichess-debug--log (if (> n 0)
-                                             "%d ongoing game(s)"
-                                           "nowPlaying = []")
-                                         n)))
+              (200
+               (let* ((j (cdr res2))
+                      (games (alist-get 'nowPlaying j))
+                      (n (length games)))
+                 (lichess-debug--log (if (> n 0)
+                                         "%d ongoing game(s)"
+                                       "nowPlaying = []")
+                                     n)))
               (_
                (lichess-debug--log "HTTP %s /account/playing"
                                    (car res2)))))))))))
@@ -87,13 +89,13 @@ ARGS are passed to `format`."
                (data (cdr res)))
            (lichess-debug--log "HTTP %d response received" status)
            (if (= status 200)
-             (progn
-               (lichess-debug--log "Data length: %d chars"
-                                   (length data))
-               (lichess-debug--log "--- RAW DATA START ---")
-               (lichess-debug--log "%s" data)
-               (lichess-debug--log "--- RAW DATA END ---"))
-           (lichess-debug--log "Error response: %s" data))))))))
+               (progn
+                 (lichess-debug--log "Data length: %d chars"
+                                     (length data))
+                 (lichess-debug--log "--- RAW DATA START ---")
+                 (lichess-debug--log "%s" data)
+                 (lichess-debug--log "--- RAW DATA END ---"))
+             (lichess-debug--log "Error response: %s" data))))))))
 
 ;;;###autoload
 (defun lichess-debug-game-stream (id)

--- a/lichess-fen.el
+++ b/lichess-fen.el
@@ -2,7 +2,7 @@
 ;;
 ;; Copyright (C) 2025-2026  Alexandr Timchenko
 ;; URL: https://github.com/tmythicator/Lichess.el
-;; Version: 0.8
+;; Version: 0.9
 ;; Package-Requires: ((emacs "27.1"))
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/lichess-game.el
+++ b/lichess-game.el
@@ -2,7 +2,7 @@
 ;;
 ;; Copyright (C) 2025-2026  Alexandr Timchenko
 ;; URL: https://github.com/tmythicator/Lichess.el
-;; Version: 0.8
+;; Version: 0.9
 ;; Package-Requires: ((emacs "27.1"))
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;; See LICENSE for details.

--- a/lichess-http.el
+++ b/lichess-http.el
@@ -2,7 +2,7 @@
 ;;
 ;; Copyright (C) 2025-2026  Alexandr Timchenko
 ;; URL: https://github.com/tmythicator/Lichess.el
-;; Version: 0.8
+;; Version: 0.9
 ;; Package-Requires: ((emacs "27.1"))
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;

--- a/lichess-http.el
+++ b/lichess-http.el
@@ -25,23 +25,21 @@
 ;;;; Header helpers
 (defun lichess-http--auth-header-line ()
   "Return raw Authorization header line for manual sockets, or \"\"."
-  (if (and (boundp 'lichess-token)
-           (stringp lichess-token)
-           (> (length lichess-token) 0))
-      (format "Authorization: Bearer %s\r\n" lichess-token)
-    ""))
+  (let ((token (lichess-token)))
+    (if (and token (stringp token) (> (length token) 0))
+        (format "Authorization: Bearer %s\r\n" token)
+      "")))
 
 (defun lichess-http--auth-headers (&optional extra accept)
   "Return an alist of headers.  Add Authorization when `lichess-token' is set.
 EXTRA (alist) is appended.  ACCEPT, when non-nil, sets Accept header."
-  (append
-   (when (and (boundp 'lichess-token)
-              (stringp lichess-token)
-              (> (length lichess-token) 0))
-     `(("Authorization" . ,(concat "Bearer " lichess-token))))
-   (when accept
-     `(("Accept" . ,accept)))
-   extra))
+  (let ((token (lichess-token)))
+    (append
+     (when (and token (stringp token) (> (length token) 0))
+       `(("Authorization" . ,(concat "Bearer " token))))
+     (when accept
+       `(("Accept" . ,accept)))
+     extra)))
 
 (defun lichess-http--abs-url (url-or-endpoint)
   "Return absolute URL for URL-OR-ENDPOINT (prepend https://lichess.org if needed)."

--- a/lichess-http.el
+++ b/lichess-http.el
@@ -22,6 +22,8 @@
 (require 'json)
 (require 'subr-x)
 
+(declare-function lichess-token "lichess")
+
 ;;;; Header helpers
 (defun lichess-http--auth-header-line ()
   "Return raw Authorization header line for manual sockets, or \"\"."

--- a/lichess-tv.el
+++ b/lichess-tv.el
@@ -2,7 +2,7 @@
 ;;
 ;; Copyright (C) 2025-2026  Alexandr Timchenko
 ;; URL: https://github.com/tmythicator/Lichess.el
-;; Version: 0.8
+;; Version: 0.9
 ;; Package-Requires: ((emacs "27.1"))
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;; See LICENSE for details.

--- a/lichess-util.el
+++ b/lichess-util.el
@@ -2,7 +2,7 @@
 ;;
 ;; Copyright (C) 2025-2026  Alexandr Timchenko
 ;; URL: https://github.com/tmythicator/Lichess.el
-;; Version: 0.8
+;; Version: 0.9
 ;; Package-Requires: ((emacs "27.1"))
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;; See LICENSE for details.

--- a/lichess.el
+++ b/lichess.el
@@ -66,8 +66,11 @@
 If `lichess-token' variable is non-nil, use that.
 Otherwise, try to retrieve it using `auth-source'."
   (or lichess-token
-      (let ((match (car (auth-source-search :host "lichess.org"
-                                            :require '(:secret)))))
+      (let ((match
+             (car
+              (auth-source-search
+               :host "lichess.org"
+               :require '(:secret)))))
         (when match
           (let ((secret (plist-get match :secret)))
             (if (functionp secret)

--- a/lichess.el
+++ b/lichess.el
@@ -5,7 +5,7 @@
 ;; Author: Alexandr Timchenko <atimchenko92@gmail.com>
 ;; Maintainer: Alexandr Timchenko <atimchenko92@gmail.com>
 ;; URL: https://github.com/tmythicator/Lichess.el
-;; Version: 0.8
+;; Version: 0.9
 ;; Package-Requires: ((emacs "27.1"))
 ;; Keywords: games, chess, lichess, api
 ;;

--- a/lichess.el
+++ b/lichess.el
@@ -50,6 +50,7 @@
 (require 'lichess-broadcast-list)
 (require 'lichess-board-tui)
 (require 'lichess-announce)
+(require 'auth-source)
 
 (defgroup lichess nil
   "Lichess client."
@@ -59,6 +60,19 @@
   "Personal Lichess API token."
   :type 'string
   :group 'lichess)
+
+(defun lichess-token ()
+  "Return Lichess Personal Access Token.
+If `lichess-token' variable is non-nil, use that.
+Otherwise, try to retrieve it using `auth-source'."
+  (or lichess-token
+      (let ((match (car (auth-source-search :host "lichess.org"
+                                            :require '(:secret)))))
+        (when match
+          (let ((secret (plist-get match :secret)))
+            (if (functionp secret)
+                (funcall secret)
+              secret))))))
 
 ;;;###autoload
 (defun lichess ()

--- a/test/dev.el
+++ b/test/dev.el
@@ -1,4 +1,4 @@
-;;; .dev.el --- Developer scratchpad for Lichess.el  -*- lexical-binding: t; -*-
+;;; dev.el --- Developer scratchpad for Lichess.el  -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 ;; This file is meant for "Rich Comment" style development.
@@ -14,10 +14,14 @@
   "Ignore BODY.  Used for rich comment blocks."
   nil)
 
-(add-to-list 'load-path default-directory)
-(require 'lichess)
-(require 'lichess-debug)
-(load-file ".secrets.el") ;; Load token
+(let ((dir (file-name-directory (or load-file-name buffer-file-name default-directory))))
+  (add-to-list 'load-path (expand-file-name ".." dir))
+  (require 'lichess)
+  (require 'lichess-debug)
+  (let ((secrets-file (expand-file-name "../.secrets.el" dir)))
+    (when (file-exists-p secrets-file)
+      (load-file secrets-file))))
+
 (message "Lichess.el development environment loaded!")
 
 ;; 2. Common Entry Points
@@ -97,4 +101,4 @@
  (lichess-fen-pos-create :stm 'b :info "Black to move")
  )
 
-;;; .dev.el ends here
+;;; dev.el ends here

--- a/test/lichess-api-test.el
+++ b/test/lichess-api-test.el
@@ -1,0 +1,41 @@
+;;; lichess-api-test.el --- Tests for lichess-api.el -*- lexical-binding: t; -*-
+
+(require 'ert)
+(require 'cl-lib)
+
+;; Add project root to load-path
+(add-to-list 'load-path (file-name-directory (directory-file-name (file-name-directory (or load-file-name (buffer-file-name))))))
+
+(require 'lichess-api)
+
+(ert-deftest lichess-api-dispatch-test ()
+  "Test that API functions route requests through `lichess-api-request-function`."
+  (let* ((calls '())
+         (lichess-api-request-function
+          (lambda (endpoint callback &rest plist)
+            (setq calls (cons (list endpoint callback plist) calls)))))
+    
+    ;; 1. GET TV channels
+    (lichess-api-get-tv-channels #'ignore)
+    (should (= (length calls) 1))
+    (should (string= (caar calls) "/api/tv/channels"))
+    (should (eq (cadar calls) #'ignore))
+    (should (equal (caddar calls) '(:method "GET" :accept "application/json" :headers nil :parse json :anonymous nil)))
+
+    ;; 2. POST AI challenge
+    (setq calls '())
+    (lichess-api-challenge-ai 5 'white 300 5 "some-fen" #'ignore nil)
+    (should (= (length calls) 1))
+    (should (string= (caar calls) "/api/challenge/ai"))
+    (should (eq (cadar calls) #'ignore))
+    (let ((plist (caddar calls)))
+      (should (string= (plist-get plist :method) "POST"))
+      (should (string-match-p "level=5" (plist-get plist :data)))
+      (should (string-match-p "color=white" (plist-get plist :data)))
+      (should (string-match-p "clock.limit=300" (plist-get plist :data)))
+      (should (string-match-p "clock.increment=5" (plist-get plist :data)))
+      (should (string-match-p "fen=some-fen" (plist-get plist :data)))
+      (should (eq (plist-get plist :parse) 'json)))))
+
+(provide 'lichess-api-test)
+;;; lichess-api-test.el ends here

--- a/test/lichess-api-test.el
+++ b/test/lichess-api-test.el
@@ -14,7 +14,7 @@
          (lichess-api-request-function
           (lambda (endpoint callback &rest plist)
             (setq calls (cons (list endpoint callback plist) calls)))))
-    
+
     ;; 1. GET TV channels
     (lichess-api-get-tv-channels #'ignore)
     (should (= (length calls) 1))
@@ -36,6 +36,32 @@
       (should (string-match-p "clock.increment=5" (plist-get plist :data)))
       (should (string-match-p "fen=some-fen" (plist-get plist :data)))
       (should (eq (plist-get plist :parse) 'json)))))
+
+(ert-deftest lichess-token-resolution-test ()
+  "Test that `lichess-token` resolves correctly using the variable and auth-source."
+  (let ((lichess-token nil))
+    ;; 1. If lichess-token is nil and auth-source returns nil, it should be nil
+    (cl-letf (((symbol-function 'auth-source-search) (lambda (&rest _args) nil)))
+      (should-not (lichess-token)))
+
+    ;; 2. If lichess-token variable is set, it should return that variable
+    (let ((lichess-token "custom-token-val"))
+      (cl-letf (((symbol-function 'auth-source-search) (lambda (&rest _args) (error "Should not be called"))))
+        (should (string= (lichess-token) "custom-token-val"))))
+
+    ;; 3. If lichess-token variable is nil, it should look up via auth-source
+    (cl-letf (((symbol-function 'auth-source-search)
+               (lambda (&rest args)
+                 (should (equal (plist-get args :host) "lichess.org"))
+                 (should (equal (plist-get args :require) '(:secret)))
+                 '((:host "lichess.org" :secret "auth-source-token-val")))))
+      (should (string= (lichess-token) "auth-source-token-val")))
+
+    ;; 4. If auth-source returns a function for secret, it should execute it
+    (cl-letf (((symbol-function 'auth-source-search)
+               (lambda (&rest _args)
+                 '((:host "lichess.org" :secret (lambda () "auth-source-func-token-val"))))))
+      (should (string= (lichess-token) "auth-source-func-token-val")))))
 
 (provide 'lichess-api-test)
 ;;; lichess-api-test.el ends here


### PR DESCRIPTION
For this we will use the built-in auth-source emacs package. It is the preferred way to authenticate now.